### PR TITLE
enhancement(input): move android underline color above spread att

### DIFF
--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -95,9 +95,9 @@ class Input extends Component {
             </View>
           )}
           <TextInput
+            underlineColorAndroid="transparent"
             {...attributes}
             ref={this._inputRef}
-            underlineColorAndroid="transparent"
             style={[styles.input, inputStyle]}
           />
           {rightIcon && (


### PR DESCRIPTION
# What does this PR do?
- Moves the ```underlineColorAndroid``` prop above the spread attributes on Input component.

# Issues
[Underline Color](https://github.com/react-native-training/react-native-elements/issues/1200)